### PR TITLE
Update config/crudi.php

### DIFF
--- a/src/config/crudi.php
+++ b/src/config/crudi.php
@@ -2,7 +2,7 @@
 
 return [
     'menu_dir_path' => app_path('menus'),
-    "logo_path"=> asset('img/logo.png'),
-    "favicon_path"=> asset('icon.png'),
+    "logo_path"=> ('img/logo.png'),
+    "favicon_path"=> ('icon.png'),
     'site_name' => env("APP_NAME",'Crudi'),
 ];


### PR DESCRIPTION
you cant use `asset()` or `url()` in a config file:

error
```
In UrlGenerator.php line 120:
                                                                                                                                                                                      
  Argument 2 passed to Illuminate\Routing\UrlGenerator::__construct() must be an instance of Illuminate\Http\Request, null given, called in /home/anskal/Desktop/01100070565/combieg  
  ypt.com/website/vendor/laravel/framework/src/Illuminate/Routing/RoutingServiceProvider.php on line 65                                                                               
                                                                                                                                                                                      
```